### PR TITLE
Update Plextras.js

### DIFF
--- a/Plextras.js
+++ b/Plextras.js
@@ -6,6 +6,9 @@ var cssBGColor = '#3f4245';
 var autohideSidebar = true;
 var showArtWorkBackground = true;
 var ShowExpandedExtras = true;
+var HideMovieExtras = false; //NOTE!!!: If TRUE make ShowExpandedExtras FALSE
+var HideCastList = false;
+var RelatedMedia = false;
 var customHeader = "Custom Links";
 var customLinks = {'Home':'javascript:switchPort(80)', 'Requests':'javascript:switchPort(3000)', 'Uptime':'https://stats.uptimerobot.com/q7BGEHzZz'};
 ////////////////////////////////////////////////////
@@ -30,12 +33,12 @@ document.getElementById('content').style.backgroundColor = cssBGColor;
 //wait X seconds before loading
 //NOTE: this doesnt play well with user chooser (plex home)
 //NOTE: would be nice to have a better trigger
-window.onload = function () {	
+window.onload = function () {
 	//start
 	loadMods();
 }
 
-window.onhashchange = function () {	
+window.onhashchange = function () {
 	//wait a bit to load custom section
 	loadMods();
 }
@@ -46,17 +49,20 @@ console.log('[Plextras.js] Starting Plextras...');
 
 	//wait a bit to load custom section
 	setTimeout(
-		function() 
-		{					
+		function()
+		{
 			loadCustomSection();
 			loadSidebarSettings();
-			loadExtrasSettings();
+      loadExtrasSettings();
+      loadExtrasSettings2();
+      loadExtrasSettings3();
+      loadExtrasSettings4();
 		},
-	delayInt);	
+	delayInt);
 }
 
 function loadCustomStyles(){
-	
+
 	if (showArtWorkBackground==true)
 	{
 		//all credit to https://github.com/uzegonemad/plexbgartwork
@@ -68,9 +74,9 @@ function loadCustomStyles(){
 }
 
 function loadExtrasSettings(){
-		
+
 	if (ShowExpandedExtras==true)
-	{		
+	{
 		console.log('[Plextras.js] expanding extras section');
 		//[class^="classname"]
 		var extrasCSS = '[class^="PrePlayExtrasList-extrasHubCell-"]>div:nth-child(2),[class^="PrePlayExtrasList-extrasHubCell-"]>div:nth-child(2)>[class^="Measure-container-"]>div>div{ height:auto!important; width: auto!important; }';
@@ -79,33 +85,66 @@ function loadExtrasSettings(){
 	}
 }
 
+function loadExtrasSettings2(){
+
+	if (HideMovieExtras==true)
+	{
+		console.log('[Plextras.js] Hiding movie extras');
+		//[class^="classname"]
+		var extrasCSS = '[class^=PrePlayExtrasList-extrasHubCell-]{display:none!important}';
+		$('head').append('<style type="text/css">'+ extrasCSS +'</style>');
+	}
+}
+
+function loadExtrasSettings3(){
+
+	if (HideCastList==true)
+	{
+		console.log('[Plextras.js] Hiding cast list');
+		//[class^="classname"]
+		var extrasCSS = '[class^=PrePlayCastList-castList-]{display:none!important}';
+		$('head').append('<style type="text/css">'+ extrasCSS +'</style>');
+	}
+}
+
+function loadExtrasSettings4(){
+
+	if (RelatedMedia==true)
+	{
+		console.log('[Plextras.js] Hiding related media');
+		//[class^="classname"]
+		var extrasCSS = '[class^=PrePlayRelatedList-relatedList-]{display:none!important}';
+		$('head').append('<style type="text/css">'+ extrasCSS +'</style>');
+	}
+}
+
 function loadSidebarSettings(){
-	
+
 	//hide sidebar
 	if (autohideSidebar==true){
-		
+
 		//kill container margin and add transition speed
-		$(".page-container").css("margin-left", "0px");	
+		$(".page-container").css("margin-left", "0px");
 		$('.sidebar-container').css("transition", "0.25s");
-		
+
 		//add hover actions
 		$('.sidebar-container').hover(function(){
 			expandSidebar();
 		}, function(){
 			contractSidebar();
-		});	
-		
+		});
+
 		//contract sidebar
 		contractSidebar();
-	}	
-	
+	}
+
 	function expandSidebar(){
 		console.log('[Plextras.js] Expanding sidebar');
 		$('.sidebar-container').css("width", "240px");
 		//this has a short delay so it waits for transition animation to finish before restoring text
 		setTimeout(
-			function() 
-			{					
+			function()
+			{
 				$('[class^="SidebarLink-title"]').removeAttr( 'style' );
 				$('[class^="SidebarServerLibraries-librariesTitle"]').removeAttr( 'style' );
 				$('[class^="SidebarList-sidebarListHeader"]').removeAttr( 'style' );
@@ -114,9 +153,9 @@ function loadSidebarSettings(){
 				$('[class^="ServerMenuButton-serverMenuTitle"]').removeAttr( 'style' );
 				$('[class^="SidebarLibraryItem-action"]').removeAttr( 'style' );
 			},
-		300);			
+		300);
 	}
-	
+
 	function contractSidebar(){
 		console.log('[Plextras.js] Contracting sidebar');
 		$('[class^="SidebarLink-title"]').css("font-size", "0px");
@@ -131,32 +170,32 @@ function loadSidebarSettings(){
 }
 
 
-function loadCustomSection(){	
+function loadCustomSection(){
 	console.log('[Plextras.js] Adding custom links section');
-	
+
 	//locate navigation sidebar
 	var navdiv = $('div[role="navigation"]').parent();
-	
+
 	//copy the 'Manage' section as a template
 	var newsec = $('div[role="navigation"]:first').clone();
-	newsec.attr('class', 'customSection');		
-		
+	newsec.attr('class', 'customSection');
+
 	//edit Section Header name
 	newsec.find('div[role="header"]').html(customHeader);
-	
+
 	//copy Settings link as template
 	var linktemplate = newsec.find("div:eq(1)");
-	
+
 	//remove all default links
-	newsec.find('[class^="SidebarListItem-sidebarListItem"]').remove();	
-	
+	newsec.find('[class^="SidebarListItem-sidebarListItem"]').remove();
+
 	//start appending custom links
 	for (var key in customLinks) {
 		newsec = newsec.clone();
-		var newlink = linktemplate;	  
+		var newlink = linktemplate;
 		newlink.find('a').attr("href", customLinks[key]);
 		newlink.find('[class^="SidebarLink-title"]').html(key);
-		newlink.find('a').attr('target', '_blank');	
+		newlink.find('a').attr('target', '_blank');
 		newsec.append(newlink);
 	}
 

--- a/Plextras.js
+++ b/Plextras.js
@@ -6,9 +6,9 @@ var cssBGColor = '#3f4245';
 var autohideSidebar = true;
 var showArtWorkBackground = true;
 var ShowExpandedExtras = true;
-var HideMovieExtras = false; //NOTE!!!: If TRUE make ShowExpandedExtras FALSE
+var HideMovieExtras = false; //NOTE!!!: ShowExpandedExtras takes priority
 var HideCastList = false;
-var RelatedMedia = false;
+var HideRelatedMedia = false;
 var customHeader = "Custom Links";
 var customLinks = {'Home':'javascript:switchPort(80)', 'Requests':'javascript:switchPort(3000)', 'Uptime':'https://stats.uptimerobot.com/q7BGEHzZz'};
 ////////////////////////////////////////////////////
@@ -52,10 +52,7 @@ console.log('[Plextras.js] Starting Plextras...');
 		function()
 		{
 			loadSidebarSettings();
-			loadExtrasSettings();
-			loadExtrasSettings2();
-			loadExtrasSettings3();
-			loadExtrasSettings4();
+			loadExtraSettings();
 			loadCustomSection();
 		},
 	delayInt);
@@ -73,48 +70,34 @@ function loadCustomStyles(){
 	}
 }
 
-function loadExtrasSettings(){
+function loadExtraSettings(){
 
 	if (ShowExpandedExtras==true)
 	{
 		console.log('[Plextras.js] expanding extras section');
-		//[class^="classname"]
-		var extrasCSS = '[class^="PrePlayExtrasList-extrasHubCell-"]>div:nth-child(2),[class^="PrePlayExtrasList-extrasHubCell-"]>div:nth-child(2)>[class^="Measure-container-"]>div>div{ height:auto!important; width: auto!important; }';
-		extrasCSS += '[class^="PrePlayExtrasList-extrasHubCell-"]>div:nth-child(2)>[class^="Measure-container-"]>div>div>div{ position:relative!important; display:inline-block; transform: translate3d(10px, 10px, 0px)!important; margin: 10px;}';
-		$('head').append('<style type="text/css">'+ extrasCSS +'</style>');
+		var expandExtrasCSS = '[class^="PrePlayExtrasList-extrasHubCell-"]>div:nth-child(2),[class^="PrePlayExtrasList-extrasHubCell-"]>div:nth-child(2)>[class^="Measure-container-"]>div>div{ height:auto!important; width: auto!important; }';
+		expandExtrasCSS += '[class^="PrePlayExtrasList-extrasHubCell-"]>div:nth-child(2)>[class^="Measure-container-"]>div>div>div{ position:relative!important; display:inline-block; transform: translate3d(10px, 10px, 0px)!important; margin: 10px;}';
+		$('head').append('<style type="text/css">'+ expandExtrasCSS +'</style>');
 	}
-}
-
-function loadExtrasSettings2(){
-
-	if (HideMovieExtras==true)
+	else if (HideMovieExtras==true)
 	{
 		console.log('[Plextras.js] Hiding movie extras');
-		//[class^="classname"]
-		var extrasCSS = '[class^=PrePlayExtrasList-extrasHubCell-]{display:none!important}';
-		$('head').append('<style type="text/css">'+ extrasCSS +'</style>');
+		var hideExtrasCSS = '[class^=PrePlayExtrasList-extrasHubCell-]{display:none!important}';
+		$('head').append('<style type="text/css">'+ hideExtrasCSS +'</style>');
 	}
-}
-
-function loadExtrasSettings3(){
 
 	if (HideCastList==true)
 	{
 		console.log('[Plextras.js] Hiding cast list');
-		//[class^="classname"]
-		var extrasCSS = '[class^=PrePlayCastList-castList-]{display:none!important}';
-		$('head').append('<style type="text/css">'+ extrasCSS +'</style>');
+		var hideCastListCSS = '[class^=PrePlayCastList-castList-]{display:none!important}';
+		$('head').append('<style type="text/css">'+ hideCastListCSS +'</style>');
 	}
-}
 
-function loadExtrasSettings4(){
-
-	if (RelatedMedia==true)
+	if (HideRelatedMedia==true)
 	{
 		console.log('[Plextras.js] Hiding related media');
-		//[class^="classname"]
-		var extrasCSS = '[class^=PrePlayRelatedList-relatedList-]{display:none!important}';
-		$('head').append('<style type="text/css">'+ extrasCSS +'</style>');
+		var HideRelatedMediaCSS = '[class^=PrePlayRelatedList-relatedList-]{display:none!important}';
+		$('head').append('<style type="text/css">'+ HideRelatedMediaCSS +'</style>');
 	}
 }
 
@@ -210,3 +193,4 @@ function switchPort(port)
 	console.log('newurl: ' + newurl);
 	window.location.href = newurl;
 }
+s

--- a/Plextras.js
+++ b/Plextras.js
@@ -51,12 +51,12 @@ console.log('[Plextras.js] Starting Plextras...');
 	setTimeout(
 		function()
 		{
-			loadCustomSection();
 			loadSidebarSettings();
-      loadExtrasSettings();
-      loadExtrasSettings2();
-      loadExtrasSettings3();
-      loadExtrasSettings4();
+			loadExtrasSettings();
+			loadExtrasSettings2();
+			loadExtrasSettings3();
+			loadExtrasSettings4();
+			loadCustomSection();
 		},
 	delayInt);
 }


### PR DESCRIPTION
~ Add 3 new options
+ Option to hide movie extras
+ Option to hide cast list
+ Option to hide related media

-Options are currently off by default, and with the way they are I don't think you could have them installing through the "Plextras.user.js" way, people will have to just use the "Plextras.js" file instead even for things like tamper/greasemonkey or have your Plextras.user.js file push variables over instead to the Plextras.js file.